### PR TITLE
Refactor CubismPhysicsJson to make use of Vector2Converter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/Vignette.Application.Live2D.Tests/bin/Debug/net5.0/Vignette.Application.Live2D.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Vignette.Application.Live2D.Tests",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Vignette.Application.Live2D.Tests/Vignette.Application.Live2D.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Vignette.Application.Live2D.Tests/Program.cs
+++ b/Vignette.Application.Live2D.Tests/Program.cs
@@ -12,7 +12,7 @@ namespace Vignette.Application.Live2D.Tests
     {
         public static void Main(string[] args)
         {
-            using GameHost host = Host.GetSuitableHost(@"visual-tests", useOsuTK: true);
+            using GameHost host = Host.GetSuitableHost(@"Vignette");
             host.Run(new VisualTestGame());
         }
     }

--- a/Vignette.Application.Live2D/Json/CubismPhysicsSetting.cs
+++ b/Vignette.Application.Live2D/Json/CubismPhysicsSetting.cs
@@ -4,6 +4,8 @@
 // License for Live2D can be found here: http://live2d.com/eula/live2d-open-software-license-agreement_en.html
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using osuTK;
 
 namespace Vignette.Application.Live2D.Json
 {
@@ -31,9 +33,11 @@ namespace Vignette.Application.Live2D.Json
 
             public class EffectiveForce
             {
-                public Vector2D Gravity { get; set; }
+                [JsonConverter(typeof(Vector2Converter))]
+                public Vector2 Gravity { get; set; }
 
-                public Vector2D Wind { get; set; }
+                [JsonConverter(typeof(Vector2Converter))]
+                public Vector2 Wind { get; set; }
             }
 
             public class PhysicsDictionaryItem
@@ -84,7 +88,8 @@ namespace Vignette.Application.Live2D.Json
 
             public class VertexSetting
             {
-                public Vector2D Position { get; set; }
+                [JsonConverter(typeof(Vector2Converter))]
+                public Vector2 Position { get; set; }
 
                 public float Mobility { get; set; }
 
@@ -117,13 +122,6 @@ namespace Vignette.Application.Live2D.Json
 
                 public float Maximum { get; set; }
             }
-        }
-
-        public class Vector2D
-        {
-            public float X { get; set; }
-
-            public float Y { get; set; }
         }
     }
 }

--- a/Vignette.Application.Live2D/Json/Vector2Converter.cs
+++ b/Vignette.Application.Live2D/Json/Vector2Converter.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Vignette Project.
+// Licensed under MIT. Please see LICENSE for more details.
+// This software implements Live2D. Copyright (c) Live2D Inc. All Rights Reserved.
+// License for Live2D can be found here: http://live2d.com/eula/live2d-open-software-license-agreement_en.html
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using osuTK;
+
+namespace Vignette.Application.Live2D.Json
+{
+    public class Vector2Converter : JsonConverter<Vector2>
+    {
+        public override Vector2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+                throw new JsonException("Expected StartObject token");
+
+            var vector = new Vector2();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                    return vector;
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                    throw new JsonException("Expected PropertyName token");
+
+                string prop = reader.GetString();
+                reader.Read();
+
+                if (prop == "X" && reader.TryGetSingle(out float x))
+                    vector.X = x;
+
+                if (prop == "Y" && reader.TryGetSingle(out float y))
+                    vector.Y = y;
+            }
+
+            throw new JsonException("Expected EndObject token");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Vector2 value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("X", value.X);
+            writer.WriteNumber("Y", value.Y);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/Vignette.Application.Live2D/Physics/CubismPhysics.cs
+++ b/Vignette.Application.Live2D/Physics/CubismPhysics.cs
@@ -30,8 +30,8 @@ namespace Vignette.Application.Live2D.Physics
 
             physicsRig = new PhysicsRig
             {
-                Gravity = new Vector2(setting.Meta.EffectiveForces.Gravity.X, setting.Meta.EffectiveForces.Gravity.Y),
-                Wind = new Vector2(setting.Meta.EffectiveForces.Wind.X, setting.Meta.EffectiveForces.Wind.Y),
+                Gravity = setting.Meta.EffectiveForces.Gravity,
+                Wind = setting.Meta.EffectiveForces.Wind,
                 SubRigs = new PhysicsSubRig[setting.Meta.PhysicsSettingCount],
             };
 
@@ -110,7 +110,7 @@ namespace Vignette.Application.Live2D.Physics
             {
                 data[i] = new PhysicsParticle
                 {
-                    InitialPosition = new Vector2(settings[i].Position.X, settings[i].Position.Y),
+                    InitialPosition = settings[i].Position,
                     Mobility = settings[i].Mobility,
                     Delay = settings[i].Delay,
                     Acceleration = settings[i].Acceleration,


### PR DESCRIPTION
Easily converts a JSON Object to `osuTK.Vector2` with the use of `JsonConverter<Vector2>` and `JsonConverterAttribute`.